### PR TITLE
Update VCML Link and add SIM-V to tools

### DIFF
--- a/docs/resources/projects.md
+++ b/docs/resources/projects.md
@@ -84,10 +84,10 @@ This is a list of open-source Virtual Platforms and Virtual Prototypes (VPs):
 
 [1]: https://github.com/accellera-official/systemc.org/issues
 [2]: https://github.com/nvdla/vp
-[3]: https://github.com/janweinstock/vcml/tree/master/src/vcml/models
+[3]: https://github.com/machineware-gmbh/vcml/tree/main/src/vcml/models
 [4]: https://github.com/aut0/vcml-nvdla
 [5]: https://github.com/Minres/SystemC-Components
-[6]: https://github.com/janweinstock/vcml
+[6]: https://github.com/machineware-gmbh/vcml
 [7]: https://github.com/aut0/avp64
 [8]: https://github.com/Minres/HIFIVE1-VP
 [9]: https://github.com/janweinstock/or1kmvp

--- a/docs/resources/tools.md
+++ b/docs/resources/tools.md
@@ -18,6 +18,7 @@ Please [let us know][issues] if an EDA tool or technology is missing or needs up
 | [Platform Architect][2] | [Synopsys][snps] | SystemC TLM 2.0 based graphical environment for early analysis and optimization of multicore SoC architectures for performance and power |
 | [Questa][6] | [Siemens EDA][siemens] | Multi-language simulation environment supporting Verilog, SystemVerilog, VHDL, and SystemC |
 | [Simulink Coder][16] | [Mathworks][mathworks] | SystemC/TLM component generator using the Simulink Coder |
+| [SIM-V][19] | [MachineWare][machineware] | RISC-V full system simulator with SystemC TLM-2.0 interfaces |
 | [Stratus HLS][12] | [Cadence][cnds] | High-level synthesis of C/C++ or SystemC descriptions to RTL |
 | [Tina][13] | [DesignSoft][tina] | Circuit Simulator for Analog, Digital, MCU and RF Circuits |
 | [VCS][9] | [Synopsys][snps] | Multi-language simulation environment supporting Verilog, SystemVerilog, VHDL, and SystemC |
@@ -47,6 +48,7 @@ Please [let us know][issues] if an EDA tool or technology is missing or needs up
 [16]: https://www.mathworks.com/help/hdlverifier/ug/getting-started-with-tlm-generator.html
 [17]: https://www.onespin.com/solutions/functional-correctness
 [18]: https://www.intel.com/content/www/us/en/cofluent/overview.html
+[19]: https://www.machineware.de/#simvcompute
 
 [coseda]: https://www.coseda-tech.com
 [snps]: https://www.synopsys.com/
@@ -59,6 +61,7 @@ Please [let us know][issues] if an EDA tool or technology is missing or needs up
 [aldec]: https://www.aldec.com/
 [nec]: https://www.nec.com/
 [mathworks]: https://www.mathworks.com/
+[machineware]: https://www.machineware.de/
 [onespin]: https://www.onespin.com/
 [intel]: https://www.intel.com/
 


### PR DESCRIPTION
Hi,

VCML was moved to MachineWare's GitHub account and I added our SIM-V simulator as well.

Thanks and best regards,
Lukas